### PR TITLE
fix: correct report_fixup return type for kernel compatibility

### DIFF
--- a/goodix-gt7868q.c
+++ b/goodix-gt7868q.c
@@ -9,7 +9,7 @@
 #include <linux/module.h>
 #include "hid-multitouch.c"
 
-static __u8 *goodix_gt7868q_report_fixup(struct hid_device *hdev, __u8 *rdesc, unsigned int *rsize)
+static const __u8 *goodix_gt7868q_report_fixup(struct hid_device *hdev, __u8 *rdesc, unsigned int *rsize)
 {
     if (rdesc[607] == 0x15) {
         rdesc[607] = 0x25;

--- a/local-overrides.quirks
+++ b/local-overrides.quirks
@@ -7,3 +7,9 @@ MatchProduct=0x01E9
 AttrPressureRange=2:0
 AttrPalmPressureThreshold=600
 AttrThumbPressureThreshold=1000
+
+[Lenovo ThinkBook 16 G7+ IAH ForcePad]
+MatchName=*GXTP5100*
+MatchDMIModalias=dmi:*svnLENOVO:*pvrThinkBook16G7+IAH*:*
+MatchUdevType=touchpad
+ModelPressurePad=1


### PR DESCRIPTION
The `goodix_gt7868q_report_fixup` function returned `__u8 *`, which is incompatible with the expected `const __u8 *` type in the `report_fixup` callback of `struct hid_driver`. This caused a compilation error on kernel 6.14.8 due to stricter type checks.

Updated the function to return `const __u8 *` to resolve the build failure and ensure proper compatibility with newer kernels.

modified the local-overrides.quirks to work properly with the 2025 Lenovo Thinkbook 16 G7+ IAH (International) touchpad.