### PR TITLE
fix: support new kernel timer APIs

### DIFF
--- a/hid-multitouch.c
+++ b/hid-multitouch.c
@@ -47,6 +47,39 @@ MODULE_LICENSE("GPL");
 
 #include "hid-ids.h"
 
+/*
+ * The timer API changed names across kernel releases:
+ * from_timer()/del_timer()* became timer_container_of()/timer_delete()*.
+ * Keep one local shim so the driver builds against both header variants.
+ */
+#ifdef timer_container_of
+#define mt_timer_container_of(var, callback_timer, timer_fieldname) \
+	timer_container_of(var, callback_timer, timer_fieldname)
+
+static inline int mt_timer_delete(struct timer_list *timer)
+{
+	return timer_delete(timer);
+}
+
+static inline int mt_timer_delete_sync(struct timer_list *timer)
+{
+	return timer_delete_sync(timer);
+}
+#else
+#define mt_timer_container_of(var, callback_timer, timer_fieldname) \
+	from_timer(var, callback_timer, timer_fieldname)
+
+static inline int mt_timer_delete(struct timer_list *timer)
+{
+	return del_timer(timer);
+}
+
+static inline int mt_timer_delete_sync(struct timer_list *timer)
+{
+	return del_timer_sync(timer);
+}
+#endif
+
 /* quirks to control the device */
 #define MT_QUIRK_NOT_SEEN_MEANS_UP	BIT(0)
 #define MT_QUIRK_SLOT_IS_CONTACTID	BIT(1)
@@ -1284,7 +1317,7 @@ static void mt_touch_report(struct hid_device *hid,
 			mod_timer(&td->release_timer,
 				  jiffies + msecs_to_jiffies(100));
 		else
-			del_timer(&td->release_timer);
+			mt_timer_delete(&td->release_timer);
 	}
 
 	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
@@ -1705,7 +1738,7 @@ static void mt_release_contacts(struct hid_device *hid)
 
 static void mt_expired_timeout(struct timer_list *t)
 {
-	struct mt_device *td = from_timer(td, t, release_timer);
+	struct mt_device *td = mt_timer_container_of(td, t, release_timer);
 	struct hid_device *hdev = td->hdev;
 
 	/*
@@ -1838,7 +1871,7 @@ static void mt_remove(struct hid_device *hdev)
 {
 	struct mt_device *td = hid_get_drvdata(hdev);
 
-	del_timer_sync(&td->release_timer);
+	mt_timer_delete_sync(&td->release_timer);
 
 	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
 	hid_hw_stop(hdev);


### PR DESCRIPTION
The kernel 6.17 renamed its timer helpers across releases (`from_timer` / `del_timer*` → `timer_container_of` / `timer_delete*`).
This adds a local compatibility shim to the vendored `hid-multitouch.c` so the module builds on both older kernels and 6.17+.

The shim uses `#ifdef timer_container_of` (a macro) for feature detection, which is more robust than `LINUX_VERSION_CODE` checks that can break on distro backports (see #18).

## Self-Test

- [x] `make` on `6.17.0-14-generic`: builds OK
- [x] `make KVERSION=6.14.0-37-generic`: builds OK
- [x] Touchpad works correctly after loading the module